### PR TITLE
Update to Pytition 2.5.1 and fix user image uploads and TinyMCE editors

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/pytition/Pytition/archive/refs/tags/v2.4.tar.gz
-SOURCE_SUM=466c788139fc90049a42d084472df36ea0f15b46766777f248ce989e3dbebcc4
+SOURCE_URL=https://github.com/pytition/Pytition/archive/refs/tags/v2.5.1.tar.gz
+SOURCE_SUM=cc65f0b10d0e38f89adeba64a2db2439721d564528ee278cf65dbc371982f501
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/config.py
+++ b/conf/config.py
@@ -28,6 +28,10 @@ ALLOWED_HOSTS = ['127.0.0.1', 'localhost', '[::1]', '__DOMAIN__']
 
 import os
 
+# This needs to be redefined because STATIC_URL might be set in this config
+# after TINYMCE_JS_URL was defined
+TINYMCE_JS_URL = STATIC_URL + TINYMCE_JS_PATH
+
 if DEFAULT_INDEX_THUMBNAIL == "":
     print("Please set a default index thumbnail or your index page will not be very beautiful")
 

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -6,7 +6,7 @@ After=network.target mysql.service
 [Service]
 Type=notify
 User=__APP__
-Group=__APP__
+Group=www-data
 WorkingDirectory=__FINALPATH__
 RuntimeDirectory=__APP__
 ExecStart=uwsgi --yaml __FINALPATH__/uwsgi.yaml --die-on-term

--- a/conf/uwsgi.yaml
+++ b/conf/uwsgi.yaml
@@ -1,7 +1,7 @@
 uwsgi:
     # Who will run the code
     uid: __APP__
-    gid: __APP__
+    gid: www-data
 
     # Number of workers
     workers: 10

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Host privacy-friendly online petitions",
         "fr": "Hébergez des pétitions en ligne respectueuses de la vie privée"
     },
-    "version": "2.4~ynh1",
+    "version": "2.5.1~ynh1",
     "url": "https://example.com",
     "upstream": {
         "license": "BSD-3-Clause",


### PR DESCRIPTION
When uploading images in mediaroot, files must have gid www-data
so that nginx can serve them.