### PR TITLE
Fix mediaroot permissions

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -94,6 +94,8 @@ mkdir -p "$final_path/mediaroot"
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
 chown -R $app:www-data "$final_path"
+setfacl -dR -m g:"www-data":rX -m u:$app:rwX "$final_path/mediaroot/"
+setfacl -R -m g:"www-data":rX -m u:$app:rwX "$final_path/mediaroot/"
 
 #=================================================
 # NGINX CONFIGURATION


### PR DESCRIPTION
This allows user to upload pictures in TinyMCE editors. The newly created files and directories, under `mediaroot/`, will allow read access to `www-data` (nginx) while still being owned by `__APP__:__APP__`
